### PR TITLE
Selective route static export for nextjs

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -4108,6 +4108,57 @@ export default async function build(
         )
       }
 
+      // Experimental: partial static export for specific routes only
+      if (config.experimental.partialStaticExport) {
+        const partialOutDir = path.join(
+          dir,
+          config.experimental.partialStaticExport.outDir || 'out-partial'
+        )
+
+        const exportApp = (
+          require('../export') as typeof import('../export')
+        ).default as typeof import('../export').default
+
+        // Build an export map limited to the requested paths
+        const partialPaths = new Set(
+          config.experimental.partialStaticExport.paths.map((p) =>
+            p === '' ? '/' : p.startsWith('/') ? p : `/${p}`
+          )
+        )
+
+        // We use a constrained export config that returns only requested paths
+        const exportConfig: NextConfigComplete = {
+          ...config,
+          // Ensure we don't try to run a full export implicitly
+          exportPathMap: async (defaultMap) => {
+            const limited: any = {}
+            for (const [k, v] of Object.entries(defaultMap)) {
+              if (partialPaths.has(k)) limited[k] = v
+            }
+            // If user requested paths that are not in defaultMap, still attempt mapping
+            for (const req of partialPaths) {
+              if (!limited[req] && defaultMap[req]) limited[req] = defaultMap[req]
+            }
+            return limited
+          },
+        }
+
+        await exportApp(
+          dir,
+          {
+            buildExport: false,
+            nextConfig: exportConfig,
+            enabledDirectories,
+            silent: true,
+            outdir: partialOutDir,
+            numWorkers: getNumberOfWorkers(exportConfig),
+            appDirOnly,
+            statusMessage: 'Exporting selected routes',
+          },
+          nextBuildSpan
+        )
+      }
+
       if (config.experimental.adapterPath) {
         await handleBuildComplete({
           dir,

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -280,6 +280,18 @@ async function exportAppImpl(
     }
   }
 
+  // When experimental.partialStaticExport is provided, we will allow exporting only
+  // the selected set of URL paths. We use this to filter the prerendered copy step below.
+  const allowedPartialExportPaths: Set<string> | null = Array.isArray(
+    nextConfig.experimental?.partialStaticExport?.paths
+  )
+    ? new Set(
+        (nextConfig.experimental!.partialStaticExport!.paths as string[]).map(
+          (p) => (p && p.startsWith('/') ? p : `/${p || ''}`) || '/'
+        )
+      )
+    : null
+
   const {
     i18n,
     images: { loader = 'default', unoptimized },
@@ -783,8 +795,26 @@ async function exportAppImpl(
   if (!options.buildExport && prerenderManifest) {
     await Promise.all(
       Object.keys(prerenderManifest.routes).map(async (unnormalizedRoute) => {
+        // If partial export is enabled, only include routes that were requested.
+        if (
+          allowedPartialExportPaths &&
+          // Special handling for /_not-found mapping to /404 below
+          unnormalizedRoute !== '/_not-found' &&
+          !allowedPartialExportPaths.has(unnormalizedRoute)
+        ) {
+          return
+        }
         // Special handling: map app /_not-found to 404.html (and 404/index.html when trailingSlash)
         if (unnormalizedRoute === '/_not-found') {
+          if (
+            allowedPartialExportPaths &&
+            !(
+              allowedPartialExportPaths.has('/404') ||
+              allowedPartialExportPaths.has('/404.html')
+            )
+          ) {
+            return
+          }
           const { srcRoute } = prerenderManifest!.routes[unnormalizedRoute]
           const appPageName = mapAppRouteToPage.get(srcRoute || '')
           const pageName = appPageName || srcRoute || unnormalizedRoute
@@ -818,6 +848,12 @@ async function exportAppImpl(
         }
         // Skip 500.html in static export
         if (unnormalizedRoute === '/_global-error') {
+          return
+        }
+        if (
+          allowedPartialExportPaths &&
+          !allowedPartialExportPaths.has(unnormalizedRoute)
+        ) {
           return
         }
         const { srcRoute } = prerenderManifest!.routes[unnormalizedRoute]

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -524,6 +524,12 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
           ])
           .optional(),
         optimizeRouterScrolling: z.boolean().optional(),
+        partialStaticExport: z
+          .strictObject({
+            paths: z.array(z.string()).min(1),
+            outDir: z.string().min(1).optional(),
+          })
+          .optional(),
       })
       .optional(),
     exportPathMap: z

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -961,6 +961,20 @@ export interface ExperimentalConfig {
    * Enable accessing root params via the `next/root-params` module.
    */
   rootParams?: boolean
+
+  /**
+   * When provided, performs a partial static export for only the specified URL paths.
+   * The export runs after a normal build and writes static files for the selected
+   * paths to the provided out directory (or "out-partial" by default).
+   *
+   * This is experimental and subject to change.
+   */
+  partialStaticExport?: {
+    /** Concrete URL paths to export, e.g. "/", "/about", "/blog/hello" */
+    paths: string[]
+    /** Optional output directory relative to project root (default: "out-partial") */
+    outDir?: string
+  }
 }
 
 export type ExportPathMap = {


### PR DESCRIPTION
## For Contributors

### Adding a feature

- [x] Implements an existing feature request or RFC. (This PR implements the request for partial static export)
- [ ] Related issues/discussions are linked using `fixes #number`
- [ ] e2e tests added
- [x] Documentation added (Usage instructions are provided below)
- [ ] Telemetry added.
- [ ] Errors have a helpful link attached

### What?

This PR introduces an `experimental.partialStaticExport` configuration option in `next.config.js`. When configured, it triggers a post-build static export process for only the specified URL paths.

### Why?

Currently, Next.js's `output: 'export'` configuration applies to the entire application, which can limit the use of server-side features like API routes or SSR. This feature provides a hybrid approach, allowing developers to generate static HTML for specific routes (e.g., marketing pages, legal documents) while retaining server-side capabilities for the rest of the application. This offers greater flexibility for deployment and performance optimization without fully committing to a static-only build.

### How?

- Added `experimental.partialStaticExport` to `NextConfig` and its validation schema.
- Integrated a post-build partial export step in `packages/next/src/build/index.ts` that runs when `experimental.partialStaticExport` is present.
- The partial export filters to only include the configured paths and writes to `out-partial` by default.
- Filtered prerendered route copying in `packages/next/src/export/index.ts` to only include the requested paths for partial export.

### How to use

In your `next.config.js`, add:
```js
/** @type {import('next').NextConfig} */
const nextConfig = {
  experimental: {
    partialStaticExport: {
      // URL paths to export as static HTML
      paths: ['/', '/about', '/pricing'],
      // optional: where to write the partial export
      outDir: 'out-partial'
    }
  }
}

module.exports = nextConfig
```

Run a normal build:
```bash
next build
```
A partial static export will be generated under `out-partial` (or your specified `outDir`), containing only the specified routes, along with necessary `_next` assets and `public/` files. The rest of the app remains a normal Next.js server build.

**Notes and constraints:**
- Intended for routes that can be statically exported (static/SSG pages).
- For App Router, any pre-rendered routes written into the build’s prerender manifest are also honored; only the requested ones are copied.
- Dynamic pages: specify the concrete URL (e.g., `/blog/hello-world`). This won’t auto-expand params.
- This does not change your app’s overall `output`; it only adds a post-build partial export step. If you set `output: 'export'`, a full export runs (as today) and the partial step is unnecessary.

---
<a href="https://cursor.com/background-agent?bcId=bc-8b430999-698f-45c4-a8c9-0eb4c00d3659">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8b430999-698f-45c4-a8c9-0eb4c00d3659">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

